### PR TITLE
Enable clang compilation.

### DIFF
--- a/device/Android.mk
+++ b/device/Android.mk
@@ -20,9 +20,6 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-# osi/include/atomic.h depends on gcc atomic functions
-LOCAL_CLANG := false
-
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/.. \
     $(LOCAL_PATH)/include \
@@ -50,9 +47,6 @@ include $(BUILD_STATIC_LIBRARY)
 #####################################################
 
 include $(CLEAR_VARS)
-
-# osi/include/atomic.h depends on gcc atomic functions
-LOCAL_CLANG := false
 
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/.. \


### PR DESCRIPTION
Files under system/bt/device do not use atomic operation.
Old setting of LOCAL_CLANG is unnecessary.

Other atomic operations in system/bt/bt/core were changed
and osi/include/atomic.h was removed, in
https://android-review.googlesource.com/#/c/166762

Change-Id: I807e1fd1792e801392f40ab92a8990c826a5785a